### PR TITLE
feat(chore): :sparkles: add an editor config file to keep a harmonize…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,107 @@
+
+# EditorConfig for Godot C# project
+# https://editorconfig.org/
+
+# Rules defined in this file:
+# - Indentation: 4 spaces for C#, tabs for GDScript/Godot files
+# - End of line: LF (Unix) for cross-platform compatibility
+# - Encoding: UTF-8 with BOM for C#
+# - Trim trailing whitespace automatically
+# - Insert final newline at end of files
+# - Maximum line length: 120 characters for C#, 80 for Markdown
+# - Brace style: Allman for C# (braces on new line)
+# - Spacing: spaces around operators, after keywords, etc.
+# - Microsoft naming conventions: PascalCase for classes/methods, _camelCase for private fields
+# - JSON/YAML files: 2 spaces indentation
+# - Project files (.csproj/.sln): 2 spaces indentation
+
+# Global configuration
 root = true
 
+# All files
 [*]
 charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# C# files (.cs)
+[*.cs]
+indent_style = space
+indent_size = 4
+max_line_length = 120
+
+# C# style conventions (for VS Code with C# extension)
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Brace style (Allman style - braces on new line)
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+
+# Indentation
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Spacing
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+
+# Naming conventions
+dotnet_naming_rule.pascal_case_for_classes.severity = warning
+dotnet_naming_rule.pascal_case_for_classes.symbols = classes
+dotnet_naming_rule.pascal_case_for_classes.style = pascal_case
+
+dotnet_naming_rule.pascal_case_for_methods.severity = warning
+dotnet_naming_rule.pascal_case_for_methods.symbols = methods
+dotnet_naming_rule.pascal_case_for_methods.style = pascal_case
+
+dotnet_naming_rule.camel_case_for_fields.severity = warning
+dotnet_naming_rule.camel_case_for_fields.symbols = private_fields
+dotnet_naming_rule.camel_case_for_fields.style = camel_case_underscore
+
+dotnet_naming_symbols.classes.applicable_kinds = class
+dotnet_naming_symbols.methods.applicable_kinds = method
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.camel_case_underscore.capitalization = camel_case
+dotnet_naming_style.camel_case_underscore.required_prefix = _
+
+# Godot files (.gd, .tscn, .tres, etc.)
+[*.gd]
+indent_style = tab
+indent_size = 4
+
+[*.{tscn,tres,godot}]
+indent_style = tab
+indent_size = 4
+
+# Configuration files
+[*.{json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = 80
+
+# Project files (.csproj, .sln)
+[*.{csproj,sln}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## 📝 **Description**  

This PR add a .editorconfig file to harmonized the code between developer 

## 🔗 **Related Issues**  

- fixes #6 

## 🛠️ **How to Test**  

 - Create a new .cs file → should auto-indent with 4 spaces
 - Press Tab in a .gd file → should use tabs
 - Trailing spaces should be removed on save
