### PR TITLE
fix: update episync workflow to push specific branches instead of mir…

### DIFF
--- a/.github/workflows/episync.yaml
+++ b/.github/workflows/episync.yaml
@@ -23,4 +23,4 @@ jobs:
           SCHOOL_REPO_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           git remote add epitech https://x-access-token:${SCHOOL_REPO_TOKEN}@github.com/EpitechPGE45-2025/G-EIP-700-PAR-7-1-eip-99.git
-          git push --mirror epitech
+          git push epitech release canary develop


### PR DESCRIPTION
## 📝 **Description**  

Add a small fix on the Github action for mirroring to avoid errors from the remote